### PR TITLE
Refactoring: oidc_response -> protocol_response

### DIFF
--- a/src/oauth2test/check.py
+++ b/src/oauth2test/check.py
@@ -91,7 +91,7 @@ class CheckRedirectErrorResponse(ExpectedError):
             try:
                 err.verify()
                 res["content"] = err.to_json()
-                conv.oidc_response.append((err, query))
+                conv.protocol_response.append((err, query))
             except MissingRequiredAttribute:
                 self._message = "Expected error message"
                 self._status = CRITICAL
@@ -118,7 +118,7 @@ class VerifyBadRequestResponse(ExpectedError):
             err = ErrorResponse().deserialize(_content, "json")
             err.verify()
             res["content"] = err.to_json()
-            conv.oidc_response.append((err, _content))
+            conv.protocol_response.append((err, _content))
         else:
             self._message = "Expected a 400 error message"
             self._status = CRITICAL
@@ -231,7 +231,7 @@ class VerifyError(Error):
             except Exception:
                 pass
 
-        item, msg = conv.oidc_response[-1]
+        item, msg = conv.protocol_response[-1]
         try:
             assert item.type().endswith("ErrorResponse")
         except AssertionError:

--- a/src/oictest/base.py
+++ b/src/oictest/base.py
@@ -27,7 +27,6 @@ class Conversation(tool.Conversation):
                                    interaction, check_factory, msg_factory,
                                    features, verbose)
         self.cis = []
-        self.oidc_response = []
         #self.item = []
         self.keyjar = self.client.keyjar
         self.position = ""
@@ -106,7 +105,7 @@ class Conversation(tool.Conversation):
                 self.trace.info("[%s]: %s" % (_qresp.type(), _qresp.to_dict()))
                 #item.append(qresp)
                 self.response_message = _qresp
-                self.oidc_response.append((_qresp, self.info))
+                self.protocol_response.append((_qresp, self.info))
                 err = None
             except Exception, err:
                 self.exception = "%s" % err

--- a/src/oictest/oic_operations.py
+++ b/src/oictest/oic_operations.py
@@ -195,7 +195,7 @@ class AuthorizationRequestCodePromptNoneWithIdToken(AuthorizationRequestCode):
 
     def __call__(self, location, response, content, features):
         idt = None
-        for (instance, msg) in self.conv.oidc_response:
+        for (instance, msg) in self.conv.protocol_response:
             if isinstance(instance, message.AccessTokenResponse):
                 idt = json.loads(msg)["id_token"]
                 break
@@ -215,7 +215,7 @@ class AuthorizationRequestCodePromptNoneWithUserID(AuthorizationRequestCode):
 
     def __call__(self, location, response, content, features):
         idt = None
-        for (instance, msg) in self.conv.oidc_response:
+        for (instance, msg) in self.conv.protocol_response:
             if isinstance(instance, message.AccessTokenResponse):
                 idt = json.loads(msg)["id_token"]
                 break
@@ -237,7 +237,7 @@ class AuthorizationRequestCodeWithUserID(AuthorizationRequestCode):
 
     def __call__(self, location, response, content, features):
         idt = None
-        for (instance, msg) in self.conv.oidc_response:
+        for (instance, msg) in self.conv.protocol_response:
             if isinstance(instance, message.AccessTokenResponse):
                 idt = json.loads(msg)["id_token"]
                 break

--- a/src/rrtest/tool.py
+++ b/src/rrtest/tool.py
@@ -11,6 +11,11 @@ __author__ = 'rolandh'
 
 
 class Conversation(object):
+    """
+    :ivar response: The received HTTP messages
+    :ivar protocol_response: List of the received protocol messages
+    """
+    
     def __init__(self, client, config, trace, interaction,
                  check_factory=None, msg_factory=None,
                  features=None, verbose=False):
@@ -27,6 +32,7 @@ class Conversation(object):
                      "rp": cookielib.CookieJar(),
                      "service": cookielib.CookieJar()}
 
+        self.protocol_response = []
         self.last_response = None
         self.last_content = None
         self.response = None


### PR DESCRIPTION
Makes the name easier to understand without referring to the
implementing class' documentation.

Also moves this member variable to the base-class
(rrtest.tool.Conversation) and adds docstring for the variable.
