### PR TITLE
Safer header copy

### DIFF
--- a/src/rrtest/request.py
+++ b/src/rrtest/request.py
@@ -114,7 +114,11 @@ class Request(object):
                 request, cis, **_kwargs)
             self.conv.cis.append(cis)
             if h_arg:
-                ht_args.update(h_arg)
+                for key in h_arg:
+                    if key in ht_args:
+                        ht_args[key].update(h_arg[key])
+                    else:
+                        ht_args[key] = h_arg[key]
             # if ht_add:
             #     ht_args.update({"headers": ht_add})
         else:


### PR DESCRIPTION
The old method would replace objects one past one level deep instead of merging them. This method assumes a dictionary of dictionaries and runs the update() call one layer in instead of the root, which has the effect of preserving both sets of headers.
