### PR TITLE
"How to use RPtest" guide link

### DIFF
--- a/test/oic_rp/op/config.py.example
+++ b/test/oic_rp/op/config.py.example
@@ -34,8 +34,8 @@ SYM_KEY = "SoLittleTime,Got"
 
 SERVER_CERT = "certs/server.crt"
 SERVER_KEY = "certs/server.key"
-#CERT_CHAIN="certs/chain.pem"
-CERT_CHAIN = None
+#CA_BUNDLE="certs/chain.pem"
+CA_BUNDLE = None
 
 KEY_EXPORT_URL = "%sstatic/jwk.json" % issuer
 

--- a/test/oic_rp/op/htdocs/registration.mako
+++ b/test/oic_rp/op/htdocs/registration.mako
@@ -108,10 +108,10 @@
     <span class="requiredText">** Required in order to generate static client credentials</span>
     <br>
 
-    <button class="btn btn-default btn-sm"
-            ng-click="go_to_test_page()">
+    <a class="btn btn-default btn-sm"
+       href="/test_list">
         Continue to test page
-    </button>
+    </a>
 
 </%block>
 

--- a/test/oic_rp/op/htdocs/rp_test_list.mako
+++ b/test/oic_rp/op/htdocs/rp_test_list.mako
@@ -24,7 +24,15 @@
 
 <%block name="body">
 
-    <h1>RP test tool</h1>
+    <div class="header">
+        <h1>RP test tool</h1>
+
+        Before you start testing please read the "how to use the RPtest" guide,
+        <a href="https://dirg.org.umu.se/static/oictest/how_to_use_rp_test.html"
+           target="_blank">
+            click here to access the guide
+        </a>
+    </div>
 
     <!-- The code which generates the rows of the test table -->
     <div ng-repeat="(category, tests) in guidlines" class="row category_row">

--- a/test/oic_rp/op/server.py
+++ b/test/oic_rp/op/server.py
@@ -665,7 +665,7 @@ if __name__ == '__main__':
     else:
         extra = ""
 
-    txt = "RP server starting listening on port:%s%s" % (config.PORT, extra)
+    txt = "RP server starting listening on port:%s%s" % (args.port, extra)
     LOGGER.info(txt)
     print txt
     try:

--- a/test/oic_rp/op/static/registration.js
+++ b/test/oic_rp/op/static/registration.js
@@ -45,14 +45,6 @@ app.controller('IndexCtrl', function ($scope, $sce, static_client_factory) {
         return redirect_uris;
 
     };
-    function redirect_to_test_list() {
-        window.open("https://dirg.org.umu.se/static/oictest/index.html");
-        window.location.replace("/test_list");
-    }
-
-    $scope.go_to_test_page = function(){
-        bootbox.confirm("Before you start testing your RP make sure to read the documentation on how to use RPtest", redirect_to_test_list)
-    }
 
     $scope.generate_client_credentials = function () {
         var redirect_uris = convert_to_simple_list($scope.redirect_uris);

--- a/test/oic_rp/op/static/rp_test_list.css
+++ b/test/oic_rp/op/static/rp_test_list.css
@@ -17,6 +17,10 @@
     margin-left: 15px;
 }
 
+.header{
+    margin: 15px;
+}
+
 .category_text{
     margin-left: 15px;
     font-size: 17px;


### PR DESCRIPTION
Added link to "How to use RPtest" guide instead of redirecting to the doc on dirg.org.umu.se when completing the registration step