### PR TITLE
Redirect URL fix

### DIFF
--- a/test/oic_op/config_server/static/op_config.js
+++ b/test/oic_op/config_server/static/op_config.js
@@ -447,6 +447,7 @@ app.controller('IndexCtrl', function ($scope, toaster, op_configuration_factory)
 
     function resetGui() {
         $scope.contains_redirect_url = false;
+        $scope.show_provider_config();
     }
 
     /**


### PR DESCRIPTION
Now when a new configuration is created or uploaded the user will be redirected to the provider configuration page