### PR TITLE
Added selected issuer to instance id page 

### DIFF
--- a/test/oic_op/config_server/config_server.py
+++ b/test/oic_op/config_server/config_server.py
@@ -764,7 +764,8 @@ def handle_request_instance_ids(response_encoder, parameters):
 
     existing_instance_ids['values'] = convert_to_gui_drop_down(instance_ids)
 
-    return response_encoder.return_json(json.dumps(existing_instance_ids))
+    return_info = {"existing_instance_ids": existing_instance_ids, "issuer": issuer}
+    return response_encoder.return_json(json.dumps(return_info))
 
 
 def handle_does_op_config_exist(session, response_encoder):
@@ -944,13 +945,19 @@ def find_static_provider_info_field(input_fields, fields_id):
 
 
 def get_issuer_from_gui_config(gui_config):
+    issuer = None
+
     if contains_dynamic_discovery_info(gui_config):
-        dynamic_disco_issuer = gui_config['fetchDynamicInfoFromServer']['input_field']['value']
-        return dynamic_disco_issuer
+        issuer = gui_config['fetchDynamicInfoFromServer']['input_field']['value']
     else:
         input_fields = gui_config['fetchStaticProviderInfo']['input_fields']
         issuer_field = find_static_provider_info_field(input_fields, "issuer")
-        return issuer_field['values']
+        issuer = issuer_field['values']
+
+    if issuer.endswith("/"):
+        issuer = issuer[:-1]
+
+    return issuer
 
 def handle_start_op_tester(session, response_encoder, parameters):
     config_gui_structure = parameters['op_configurations']

--- a/test/oic_op/config_server/htdocs/op_config.mako
+++ b/test/oic_op/config_server/htdocs/op_config.mako
@@ -204,6 +204,9 @@
             <!-- ################################################################################################# -->
             <div ng-show="test_instance_tab_visible">
 
+                Instances connected to issuer: <b>{{selected_issuer}}</b>
+                <br>
+
                 The application supports up to five test tool instances connected to the same issuer. The test tool
                 instances are separated by an id chosen by the user.
                 <br>

--- a/test/oic_op/config_server/static/op_config.js
+++ b/test/oic_op/config_server/static/op_config.js
@@ -193,9 +193,11 @@ app.controller('IndexCtrl', function ($scope, toaster, op_configuration_factory)
     };
 
     $scope.existing_instance_ids = {};
+    $scope.selected_issuer = ""
 
     function request_instance_ids_success_callback(data, status, headers, config) {
-        $scope.existing_instance_ids = data;
+        $scope.existing_instance_ids = data['existing_instance_ids'];
+        $scope.selected_issuer = data['issuer'];
         $scope.show_test_instance_config()
     }
 


### PR DESCRIPTION
Now shows the selected issuer on instance ID page. Removes last character if issuer ends with /