### PR TITLE
Fix import JSON_ENCODED error in oic_operations.py

### DIFF
--- a/src/oictest/oic_operations.py
+++ b/src/oictest/oic_operations.py
@@ -26,7 +26,8 @@ __author__ = 'rohe0002'
 import time
 
 from urllib import urlencode
-from oic.oauth2 import JSON_ENCODED, PBase
+from oic.oauth2.util import JSON_ENCODED
+from oic.oauth2 import PBase
 
 # Used upstream not in this module so don't remove
 from oictest.check import *


### PR DESCRIPTION
@rohe and @stianst 

I believe this should fix issue rohe/oictest#66.  Seems to be just a simple typo to me, but I'm certainly no python expert.  But, this bug effectively kills all of the utilities.

