### PR TITLE
Fix for typo in id_token validation.

### DIFF
--- a/test/oic_op/rp/gsma/message.py
+++ b/test/oic_op/rp/gsma/message.py
@@ -111,19 +111,19 @@ class IdToken(OpenIDSchema):
                     raise NotForMe("", self)
 
             if len(self["aud"]) > 1:
-                # Then azr has to be present and be one of the aud values
+                # Then azp has to be present and be one of the aud values
                 try:
-                    assert "azr" in self
+                    assert "azp" in self
                 except AssertionError:
-                    raise VerificationError("azr missing", self)
+                    raise VerificationError("azp missing", self)
                 else:
                     try:
-                        assert self["azr"] in self["aud"]
+                        assert self["azp"] in self["aud"]
                     except AssertionError:
                         raise VerificationError(
-                            "Mismatch between azr and aud claims", self)
+                            "Mismatch between azp and aud claims", self)
 
-        if "azr" in self:
+        if "azp" in self:
             if "client_id" in kwargs:
                 if kwargs["client_id"] != self["azp"]:
                     raise NotForMe("", self)


### PR DESCRIPTION
    • If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
    • If an azp (authorized party) Claim is present, the Client SHOULD verify that its client_id is the Claim Value.