### PR TITLE
ensure array for OP-claims-acr=1

### DIFF
--- a/src/oictest/testfunc.py
+++ b/src/oictest/testfunc.py
@@ -209,10 +209,12 @@ def sub_claims(request_args, conv, kwargs):
 def specific_acr_claims(request_args, conv, kwargs):
     try:
         _acrs = conv.client_config["acr_values"]
+        if isinstance(_acrs, basestring):
+            _acrs = _acrs.split(" ")
     except KeyError:
         _acrs = ["2"]
 
-    request_args["claims"] = {"id_token": {"acr": {"values": _acrs}}}
+    request_args["claims"] = {"id_token": {"acr": {"essential": True, "values": _acrs}}}
     return request_args
 
 


### PR DESCRIPTION
Given that `OP-claims-acr=1` is testing [5.5.5.1. Requesting the "acr" Claim](http://openid.net/specs/openid-connect-core-1_0.html#acrSemantics), specifically that when acr is requested as essential claim with specific value or values provided the test should actually provide the `"essential":true` property of the given claim. In addition test instances launched through the web interface have the `conv.client_config["acr_values"]` stored as string, this PR ensures the acr claim is requested as essential with Array of members as the `values` property.